### PR TITLE
Update Github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ $ gpt_translate.folder \
   --input_folder docs \
   --out_folder docs_ja \
   --language ja
-$ gpt_translate.file --help
 ```
 
 If you don't know what to do, you can always do `--help` on any of the commands:
@@ -133,6 +132,11 @@ $ gpt_translate.folder \
 
 ![Weave Tracing](./assets/weave.png)
 
+## Github Action
+
+We supply a `action.yml` file to use this library in a Github Action. It is not much tested, but it should work.
+
+- You will need to setup your [Weights & Biases](https://wandb.ai/site) API key as a secret in your Github repository as `WANDB_API_KEY`.
 
 ## TroubleShooting
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ We supply a `action.yml` file to use this library in a Github Action. It is not 
 
 - You will need to setup your [Weights & Biases](https://wandb.ai/site) API key as a secret in your Github repository as `WANDB_API_KEY`.
 
+An example workflow is shown in https://github.com/tcapelle/dummy_docs and the [corresponding workflow file](https://github.com/tcapelle/dummy_docs/blob/main/.github/workflows/main.yml)
+
 ## TroubleShooting
 
 If you have any issue, you can always pass the `--debug` flag to get more information about what is happening:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ $ gpt_translate.folder \
 
 ## Github Action
 
-We supply a `action.yml` file to use this library in a Github Action. It is not much tested, but it should work.
+We supply an [action.yml file](action.yml) to use this library in a Github Action. It is not much tested, but it should work.
 
 - You will need to setup your [Weights & Biases](https://wandb.ai/site) API key as a secret in your Github repository as `WANDB_API_KEY`.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ $ gpt_translate.file \
   --input_file README.md \
   --out_file README_es_.md \
   --language es
+  --config_folder ./configs
 ```
 
 2. Translate a list of files from `list.txt`:
@@ -90,6 +91,7 @@ $ gpt_translate.files \
   --input_folder docs \ 
   --out_folder docs_ja \
   --language ja
+  --config_folder ./configs
 ```
 
 Note here that we need to pass and input and output folder. This is because we will be using the input folder to get the relative path and create the same folder structure in the output folder. This is tipically what you want for documentation websites that are organized in folders like `./docs`.
@@ -101,6 +103,7 @@ $ gpt_translate.folder \
   --input_folder docs \
   --out_folder docs_ja \
   --language ja
+  --config_folder ./configs
 ```
 
 If you don't know what to do, you can always do `--help` on any of the commands:
@@ -128,6 +131,7 @@ $ gpt_translate.folder \
   --output_folder docs_ja \
   --language ja \
   --weave_project gpt-translate
+  --config_folder ./configs
 ```
 
 ![Weave Tracing](./assets/weave.png)

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,14 @@ runs:
     - name: Get changed files
       id: changed-files
       run: |
-        echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.(md|mdx)$' | xargs)" >> $GITHUB_OUTPUT
+        changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.md$' | xargs)
+        if [ -z "$changed_files" ]; then
+          echo "No changed Markdown files found."
+          echo "changed_files=" >> $GITHUB_OUTPUT
+        else
+          echo "Changed Markdown files: $changed_files"
+          echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
+        fi
         echo "$GITHUB_OUTPUT"
       shell: bash
     - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install git+https://github.com/tcapelle/gpt_translate.git@action#egg=gpt_translate
+        python -m pip install gpt_translate
       shell: bash
     - name: Create file list or use input file
       run: |

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Get changed files
       id: changed-files
       run: |
-        changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.md$' | xargs)
+        changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep -E '\.(md|mdx)$' | xargs)
         if [ -z "$changed_files" ]; then
           echo "No changed Markdown files found."
           echo "changed_files=" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -1,23 +1,25 @@
 name: 'Translate'
 description: 'Automatic translation using GPT'
 inputs:
-  folder-to-translate:  # id of input
+  folder-to-translate:
     description: 'Path to folder to translate'
     required: true
     default: 'docs/'
-  language:  # id of input
+  language:
     description: 'Language to translate to'
     required: true
     default: 'es'
   output-folder:
     description: "Output Folder"
     default: 'docs_translated/'
-  max-chunk-tokens:
-    description: "Max size of chunk to translate at once"
-    default: "1000"
   config-folder:
     description: "Config Folder"
     default: './configs'
+  weave-project:
+    description: "Weave project name"
+    required: false
+    default: 'my_docs_translation'
+
 outputs:
   translated-files:
     description: 'Translated files'
@@ -29,20 +31,24 @@ runs:
     - name: Get changed files
       id: changed-files
       run: |
-          echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.md$' | xargs)" >> $GITHUB_OUTPUT
+        echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.md$' | xargs)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install gpt-translate
       shell: bash
-    - name: translating files
+    - name: Create file list
       run: |
-        gpt_translate.files ${{ steps.changed-files.outputs.changed_files }} \
+        echo "${{ steps.changed-files.outputs.changed_files }}" | tr ' ' '\n' > files_to_translate.txt
+      shell: bash
+    - name: Translating files
+      run: |
+        gpt_translate.files files_to_translate.txt \
           --input_folder ${{ inputs.folder-to-translate }} \
           --out_folder ${{ inputs.output-folder }} \
           --language ${{ inputs.language }} \
-          --max_chunk_tokens ${{ inputs.max-chunk-tokens }} \
           --config_folder ${{ inputs.config-folder }} \
-          --replace
+          --replace \
+          --weave_project ${{ inputs.weave-project }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .
+        python -m pip install git+https://github.com/tcapelle/gpt_translate.git@$GITHUB_REF_NAME#egg=gpt_translate
       shell: bash
     - name: Create file list
       run: |

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install git+https://github.com/tcapelle/gpt_translate.git@$GITHUB_REF_NAME#egg=gpt_translate
+        python -m pip install git+https://github.com/tcapelle/gpt_translate.git@action#egg=gpt_translate
       shell: bash
     - name: Create file list
       run: |

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install gpt-translate
+        python -m pip install -e .
       shell: bash
     - name: Create file list
       run: |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
       id: changed-files
       run: |
         echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.(md|mdx)$' | xargs)" >> $GITHUB_OUTPUT
+        echo "$GITHUB_OUTPUT"
       shell: bash
     - name: Install dependencies
       run: |

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: 'Translate'
 description: 'Automatic translation using GPT'
+
 inputs:
   folder-to-translate:
     description: 'Path to folder to translate'
@@ -20,13 +21,15 @@ inputs:
     required: false
     default: 'my_docs_translation'
   input-file:
-    description: "Input file"
+    description: "Input .txt file with list of files to translate"
     required: false
 
 outputs:
   translated-files:
     description: 'Translated files'
     value: ${{ steps.changed-files.outputs.changed_files }} 
+
+
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Get changed files
       id: changed-files
       run: |
-        echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.md$' | xargs)" >> $GITHUB_OUTPUT
+        echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | grep '\.(md|mdx)$' | xargs)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Install dependencies
       run: |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: "Weave project name"
     required: false
     default: 'my_docs_translation'
+  input-file:
+    description: "Input file"
+    required: false
 
 outputs:
   translated-files:
@@ -38,9 +41,15 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install git+https://github.com/tcapelle/gpt_translate.git@action#egg=gpt_translate
       shell: bash
-    - name: Create file list
+    - name: Create file list or use input file
       run: |
-        echo "${{ steps.changed-files.outputs.changed_files }}" | tr ' ' '\n' > files_to_translate.txt
+        if [ -n "${{ inputs.input-file }}" ]; then
+          echo "Using provided input file: ${{ inputs.input-file }}"
+          cp "${{ inputs.input-file }}" files_to_translate.txt
+        else
+          echo "Creating file list from changed files"
+          echo "${{ steps.changed-files.outputs.changed_files }}" | tr ' ' '\n' > files_to_translate.txt
+        fi
       shell: bash
     - name: Translating files
       run: |

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,8 @@ runs:
       shell: bash
     - name: Translating files
       run: |
-        gpt_translate.files files_to_translate.txt \
+        gpt_translate.files \
+          --input_file files_to_translate.txt \
           --input_folder ${{ inputs.folder-to-translate }} \
           --out_folder ${{ inputs.output-folder }} \
           --language ${{ inputs.language }} \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "fastcore>=1.5.29",
     "weave>=0.50.3",
     "tqdm>=4.66.4",
+    "simple_parsing>=0.1.5",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tiktoken
 wandb
 tqdm
 weave
+simple_parsing


### PR DESCRIPTION
- max_chunk_tokens is not used anymore.
- gpt_translate.files requires a text files with one file per line, not just a bunch of inputs
- we shuold also pass an extra param --weave_project my_docs_translation to gpt_translate

Maybe addressing some of: #10

Also updating this repo as example: https://github.com/tcapelle/dummy_docs