### PR TITLE
Update loader.py

### DIFF
--- a/src/gpt_translate/loader.py
+++ b/src/gpt_translate/loader.py
@@ -81,6 +81,8 @@ class Header:
     slug: Optional[str] = None
     displayed_sidebar: Optional[str] = None
     toc_max_heading_level: Optional[int] = None
+    sidebar_position: Optional[int] = None
+
     imports: Optional[str] = None
 
     @classmethod


### PR DESCRIPTION
Allow sidebar_position in frontmatter

Docusaurus orders docs in the sidebar alphabetically by default, sidebar_position allows customizing the order.