### PR TITLE
Update prompts.py

### DIFF
--- a/src/gpt_translate/prompts.py
+++ b/src/gpt_translate/prompts.py
@@ -4,6 +4,7 @@ import weave
 
 LANGUAGES_DICT = {
     "es": "Spanish",
+    "en": "English",
     "ja": "Japanese",
     "fr": "French",
     "de": "German",


### PR DESCRIPTION
Allow translation to English.

I tried translating from Chinese to English and saw this:
```
ERROR    ❌ Error translating ../zh/quick_start/quick_start.mdx: 'en'
...
  File "/opt/homebrew/lib/python3.11/site-packages/gpt_translate/prompts.py", line 81, in format
    output_language=LANGUAGES_DICT[self.language],
                    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
```
So I added English to the LANGUAGES_DICT and was able to translate to English.

I hope that you are well!