### PR TITLE
Update system_prompt.txt

### DIFF
--- a/configs/system_prompt.txt
+++ b/configs/system_prompt.txt
@@ -23,3 +23,4 @@ Here is the translation dictionary for domain specific words. Use the dictionary
 [track metrics](./guides/track), [create logs](./guides/artifacts).
 - Beware with <Tabs> and <TabItem> formatting. Respect spacing and newlines around this important constructs. Specially after lists, be sure to keep the same spacing. It is a double newline after the list.
 - For inline formatting (italic, bold, strikethrough, inline code) in japanese, consider adding spaces before and after when applying to part of a word/phrase. For example "_A_ and _B_" should be translated as "_A_ と _B_", not "_A_と_B_". Without spaces, the translated markdown does not work.
+- When translating to Japanese add a space when switching between alphabets and Japanese characters including Kanji, Hiragana, and Katagana.


### PR DESCRIPTION
We are getting started with translating to Japanese. In our first test we noticed that there were some instances where no space was included between alphabets and Japanese characters including Kanji, Hiragana, and Katagana. Adding a reminder to the system prompt seems to have fixed this for us, but we have only done limited testing.